### PR TITLE
Handle missing command and add usage

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -32,6 +32,19 @@ namespace EditPadToolHelper
             string thisCommandLine = Win32.GetCommandLine();
             string targetCommandLine = Win32.GetCommandLineArgs(thisCommandLine);
             string targetCommand = Win32.GetCommandLineCmd(targetCommandLine);
+            if (string.IsNullOrWhiteSpace(targetCommand))
+            {
+                const string usage = "Usage: EditPadToolHelper <command> [args]";
+                try
+                {
+                    MessageBox.Show(usage, "Usage", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                }
+                catch
+                {
+                    Console.Error.WriteLine(usage);
+                }
+                Environment.Exit(1);
+            }
             string targetArgs = Win32.GetCommandLineArgs(targetCommandLine);
 
             Stream helperStdIn = null;

--- a/README.md
+++ b/README.md
@@ -1,7 +1,1 @@
-# EditPadToolHelper
 
-Run a command through the helper so EditPad can capture its output.
-
-```
-EditPadToolHelper <command> [arguments]
-```

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# 
+# EditPadToolHelper
+
+Run a command through the helper so EditPad can capture its output.
+
+```
+EditPadToolHelper <command> [arguments]
+```


### PR DESCRIPTION
## Summary
- show a usage message if no command is specified
- document basic usage in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68756afee080832f9a1dac6cd3884873