### PR TITLE
Increase copy buffer size

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -123,7 +123,7 @@ namespace EditPadToolHelper
 
         public static void CopyDataRemovingWindowsEOF(Stream src, Stream dst)
         {
-            const int BUFSZ = 16;
+            const int BUFSZ = 4096;
             byte[] buf = new byte[BUFSZ];
             byte[] priorBuf = new byte[BUFSZ];
             int priorBufLen = 0;


### PR DESCRIPTION
## Summary
- bump BUFSZ from 16 to 4096 in `CopyDataRemovingWindowsEOF`
- verified copying large input still works

## Testing
- `xbuild EditPadToolHelper.sln`
- `mono test.exe | head -n 3`

------
https://chatgpt.com/codex/tasks/task_b_68756affad10832fac6064d7453cca08